### PR TITLE
Fix Issue #13 - Markdown 2.5 compatibiltiy problems

### DIFF
--- a/math.py
+++ b/math.py
@@ -141,7 +141,7 @@ def mathjax_for_markdown(pelicanobj, mathjax_settings):
 
     # Create the configuration for the markdown template
     config = {}
-    config['mathjax_script'] = [process_mathjax_script(mathjax_settings),'Mathjax JavaScript script']
+    config['mathjax_script'] = process_mathjax_script(mathjax_settings)
     
     # Instantiate markdown extension and append it to the current extensions
     try:

--- a/pelican_mathjax_markdown_extension.py
+++ b/pelican_mathjax_markdown_extension.py
@@ -49,7 +49,7 @@ class PelicanMathJaxTreeProcessor(markdown.treeprocessors.Treeprocessor):
         # Add the mathjax script to the html document
         mathjax_script = etree.Element('script')
         mathjax_script.set('type','text/javascript')
-        mathjax_script.text = AtomicString(self.pelican_mathjax_extension.getConfig('mathjax_script')[0])
+        mathjax_script.text = AtomicString(self.pelican_mathjax_extension.getConfig('mathjax_script'))
         root.append(mathjax_script)
 
         # Reset the boolean switch to false so that script is only added


### PR DESCRIPTION
This should fix #13 . Apologies for any accidental inclusion of tabs, I seem to be good at that..

Not tested with Python 3.
