### PR TITLE
Allow loading LaTeX user-defined macros from text files

### DIFF
--- a/Contribute.md
+++ b/Contribute.md
@@ -1,0 +1,7 @@
+Local development
+=================
+
+1.  Create a virtual environment and install packages via `pip` from `devrequirements.txt`
+2.  Add your tests to `test_math.py`
+3.  In the CLI run `python -m unittest discover -t ..`
+

--- a/Readme.md
+++ b/Readme.md
@@ -52,6 +52,14 @@ the math output in the summary.
 To restore math, [BeautifulSoup4](https://pypi.python.org/pypi/beautifulsoup4/4.4.0)
 is used. If it is not installed, no summary processing will happen.
 
+### Load custom LaTeX macros
+
+If you use the same macros over and over, it's a good idea to not repeat yourself defining them in multiple Markdown or reStructuredText documents. What you can do instead is tell the plugin absolute paths for text files containing macro definitions. 
+
+If the same macro name has multiple definitions, the last one is used and a warning is printed to stdout.
+
+See below in the Usage section for examples.
+
 Usage
 -----
 ### Templates
@@ -99,11 +107,15 @@ Requires [BeautifulSoup4](http://www.crummy.com/software/BeautifulSoup/bs4/doc/)
 **Default Value**: `False`
  * `message_style`: [string] This value controls the verbosity of the messages in the lower left-hand corner. Set it to `None` to eliminate all messages.
 **Default Value**: normal
+* `macros`: [list] each element of the list is a [string] containing the absolute path to a file with macro definitions.
+**Default Value**: `[]`
 
 #### Settings Examples
-Make math render in blue and displaymath align to the left:
+Make math render in blue, displaymath align to the left and load macros from `/home/user/latex-macros.tex`:
 
-    MATH_JAX = {'color':'blue','align':left}
+    macros = ['/home/user/latex-macros.tex']
+    MATH_JAX = {'color': 'blue', 'align': 'left', 'macros': macros}
+
 
 Use the [color](http://docs.mathjax.org/en/latest/tex.html#color) and
 [mhchem](http://docs.mathjax.org/en/latest/tex.html#mhchem) extensions:

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,1 @@
-from .math import *
+from .render_math import *

--- a/devrequirements.txt
+++ b/devrequirements.txt
@@ -1,0 +1,11 @@
+Jinja2==2.8
+MarkupSafe==0.23
+Pygments==2.1
+Unidecode==0.04.19
+blinker==1.4
+docutils==0.12
+feedgenerator==1.7
+pelican==3.6.3
+python-dateutil==2.4.2
+pytz==2015.7
+six==1.10.0

--- a/latex-commands-example.tex
+++ b/latex-commands-example.tex
@@ -1,0 +1,3 @@
+\newcommand{\pp}[2]{\frac{\partial #1}{\partial #2}}
+\newcommand{\bb}{\pi R}
+\newcommand{\bc}{\pi r}

--- a/mathjax_script_template
+++ b/mathjax_script_template
@@ -18,7 +18,7 @@ if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {{
     mathjaxscript[(window.opera ? "innerHTML" : "text")] =
         "MathJax.Hub.Config({{" +
         "    config: ['MMLorHTML.js']," +
-        "    TeX: {{ extensions: ['AMSmath.js','AMSsymbols.js','noErrors.js','noUndefined.js'{tex_extensions}], equationNumbers: {{ autoNumber: 'AMS' }} }}," +
+        "    TeX: {{ extensions: ['AMSmath.js','AMSsymbols.js','noErrors.js','noUndefined.js'{tex_extensions}], equationNumbers: {{ autoNumber: 'AMS' }}, Macros: {macros} }}," +
         "    jax: ['input/TeX','input/MathML','output/HTML-CSS']," +
         "    extensions: ['tex2jax.js','mml2jax.js','MathMenu.js','MathZoom.js']," +
         "    displayAlign: '"+ align +"'," +

--- a/test_math.py
+++ b/test_math.py
@@ -1,0 +1,84 @@
+import os
+import unittest
+from render_math import parse_tex_macros, _parse_macro, _filter_duplicates
+
+class TestParseMacros(unittest.TestCase):
+    def test_multiple_arguments(self):
+        """Parse a definition with multiple arguments"""
+        text = r'\newcommand{\pp}[2]{\frac{ #1}{ #2} \cdot 2}'
+        line = {'filename': '/home/user/example.tex', 'line_num': 1, 'def':
+            text}
+        parsed = _parse_macro(line)
+        expected = {'name':'pp',
+                     'definition': '\\\\\\\\frac{ #1}{ #2} \\\\\\\\cdot 2',
+                     'args': '2',
+                    'line': 1,
+                    'file': '/home/user/example.tex'}
+        self.assertEqual(parsed, expected)
+
+    def test_no_arguments(self):
+        """Parse a definition without arguments"""
+        text = r'\newcommand{\circ}{2 \pi R}'
+        line = {'filename': '/home/user/example.tex', 'line_num': 1, 'def':
+            text}
+        parsed = _parse_macro(line)
+        expected = {'name':'circ',
+                     'definition': '2 \\\\\\\\pi R',
+                    'line': 1,
+                    'file': '/home/user/example.tex'
+                     }
+        self.assertEqual(parsed, expected)
+
+    def test_repeated_definitions_same_file(self):
+        """Last definition is used"""
+        text1 = r'2 \\\\\\\\pi R'
+        text2 = r'2 \\\\\\\\pi r'
+        common_file = '/home/user/example.tex'
+        def1 = {'name': 'circ', 'line': 1, 'definition': text1,
+                 'file': common_file}
+        def2 = {'name': 'circ', 'line': 2, 'definition': text2,
+                 'file': common_file}
+        expected = [{'name':'circ',
+                     'definition': r'2 \\\\\\\\pi r',
+                     'line': 2,
+                     'file': '/home/user/example.tex'
+                     }]
+        parsed = _filter_duplicates(def1, def2)
+        self.assertEqual(parsed, expected)
+
+    def test_repeated_definitions_different_files(self):
+        """Last definition is used"""
+        text1 = r'2 \\\\\\\\pi R'
+        text2 = r'2 \\\\\\\\pi r'
+        file1 = '/home/user/example1.tex'
+        file2 = '/home/user/example2.tex'
+        def1 = {'name': 'circ', 'line': 1, 'definition': text1,
+                 'file': file1}
+        def2 = {'name': 'circ', 'line': 1, 'definition': text2,
+                 'file': file2}
+        expected = [{'name':'circ',
+                     'definition': r'2 \\\\\\\\pi r',
+                     'line': 1,
+                     'file': '/home/user/example2.tex'
+                     }]
+        parsed = _filter_duplicates(def1, def2)
+        self.assertEqual(parsed, expected)
+
+    def test_load_file(self):
+        cur_dir = os.path.split(os.path.realpath(__file__))[0]
+        test_fname = os.path.join(cur_dir, "latex-commands-example.tex")
+        parsed = parse_tex_macros([test_fname])
+        expected = [{'name': 'pp',
+                     'definition': '\\\\\\\\frac{\\\\\\\\partial #1}{'
+                                   '\\\\\\\\partial #2}',
+                     'args': '2'},
+                    {'name': 'bb',
+                     'definition': '\\\\\\\\pi R',},
+                    {'name': 'bc',
+                     'definition': '\\\\\\\\pi r',
+                     }]
+        self.maxDiff = None
+        self.assertEqual(parsed, expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi,
thanks for the plugin first of all, it's very useful!

You may know that Mathjax supports [custom macros](http://mathjax.readthedocs.org/en/latest/tex.html#defining-tex-macros), by writing them in LaTeX syntax inside $ $ or $$ $$, but also by adding an option `Macros` to `MathJax.Hub.Config`, in javascript style of course.

I usually find myself using the same definitions, in order to avoid repetitions I added a function that parses and loads definitions from tex files.

I'm not a professional programmer, therefore suggestions to improve the code are welcome.