### PR TITLE
Render math for drafts as well

### DIFF
--- a/render_math.py
+++ b/render_math.py
@@ -459,7 +459,7 @@ def process_rst_and_summaries(content_generators):
 
     for generator in content_generators:
         if isinstance(generator, generators.ArticlesGenerator):
-            for article in generator.articles + generator.translations:
+            for article in generator.articles + generator.translations + generator.drafts:
                 rst_add_mathjax(article)
                 #optionally fix truncated formulae in summaries.
                 if process_summary.mathjax_script is not None:


### PR DESCRIPTION
You do not want to publish mathematical articles you never saw in rendered representation. This feature could also be controlled by an option.