### PR TITLE
fix location protocol manipulation

### DIFF
--- a/mathjax_script_template
+++ b/mathjax_script_template
@@ -10,8 +10,8 @@ if (!document.getElementById('mathjaxscript_pelican_#%@#$@#')) {{
     }}
 
     var mathjaxscript = document.createElement('script');
-    var location_protocol = ({force_tls}) ? 'https' : document.location.protocol;
-    if (location_protocol !== 'http' && location_protocol !== 'https') location_protocol = 'https:';
+    var location_protocol = ({force_tls}) ? 'https:' : document.location.protocol;
+    if (location_protocol !== 'http:' && location_protocol !== 'https:') location_protocol = 'https:';
     mathjaxscript.id = 'mathjaxscript_pelican_#%@#$@#';
     mathjaxscript.type = 'text/javascript';
     mathjaxscript.src = location_protocol + {source};


### PR DESCRIPTION
A few colons are missing from `mathjax_script_template` -- `document.location.protocol` returns either `http:` or `https:`.