### PR TITLE
pelican3.7.0

### DIFF
--- a/render_math.py
+++ b/render_math.py
@@ -321,7 +321,7 @@ def process_summary(article):
     """Ensures summaries are not cut off. Also inserts
     mathjax script so that math will be rendered"""
 
-    summary = article._get_summary()
+    summary = article.summary
     summary_parsed = BeautifulSoup(summary, 'html.parser')
     math = summary_parsed.find_all(class_='math')
 
@@ -388,7 +388,17 @@ def mathjax_for_markdown(pelicanobj, mathjax_script, mathjax_settings):
 
     # Instantiate markdown extension and append it to the current extensions
     try:
-        pelicanobj.settings['MD_EXTENSIONS'].append(PelicanMathJaxExtension(config))
+        if 'MARKDOWN' in pelicanobj.settings:
+            mathjax = PelicanMathJaxExtension(config)
+            if 'extensions' in pelicanobj.settings['MARKDOWN']:
+                pelicanobj.settings['MARKDOWN']['extensions'].append(mathjax)
+            else:
+                pelicanobj.settings['MARKDOWN']['extensions'] = [mathjax]
+        elif 'MD_EXTENSIONS' in pelicanobj.settings:
+            pelicanobj.settings['MD_EXTENSIONS'].append(
+                PelicanMathJaxExtension(config))
+        else:
+            raise LookupError("Could not find pelicanobj.settings['MARKDOWN']")
     except:
         sys.excepthook(*sys.exc_info())
         sys.stderr.write("\nError - the pelican mathjax markdown extension failed to configure. MathJax is non-functional.\n")

--- a/render_math.py
+++ b/render_math.py
@@ -321,7 +321,7 @@ def process_summary(article):
     """Ensures summaries are not cut off. Also inserts
     mathjax script so that math will be rendered"""
 
-    summary = article._get_summary()
+    summary = article.summary
     summary_parsed = BeautifulSoup(summary, 'html.parser')
     math = summary_parsed.find_all(class_='math')
 
@@ -388,7 +388,17 @@ def mathjax_for_markdown(pelicanobj, mathjax_script, mathjax_settings):
 
     # Instantiate markdown extension and append it to the current extensions
     try:
-        pelicanobj.settings['MD_EXTENSIONS'].append(PelicanMathJaxExtension(config))
+        if 'MARKDOWN' in pelicanobj.settings:
+            mathjax = PelicanMathJaxExtension(config)
+            if 'extensions' in pelicanobj.settings['MARKDOWN']:
+                pelicanobj.settings['MARKDOWN']['extension'].append(mathjax)
+            else:
+                pelicanobj.settings['MARKDOWN']['extensions'] = [mathjax]
+        elif 'MD_EXTENSIONS' in pelicanobj.settings:
+            pelicanobj.settings['MD_EXTENSIONS'].append(
+                PelicanMathJaxExtension(config))
+        else:
+            raise LookupError("Could not find pelicanobj.settings['MARKDOWN']")
     except:
         sys.excepthook(*sys.exc_info())
         sys.stderr.write("\nError - the pelican mathjax markdown extension failed to configure. MathJax is non-functional.\n")


### PR DESCRIPTION
I believe this will fix #38 reported by @szhorvat.

I'm a bit of a noob to python, git, github, pelican, mathjax, but it seems to work and the unittest seem to work:

```bash
$ python test_math.py
Traceback (most recent call last):
  File "test_math.py", line 3, in <module>
    from .render_math import parse_tex_macros, _parse_macro, _filter_duplicates
ValueError: Attempted relative import in non-package
(py2) Dell15:~/d/workspace/upstream.pelican/pelican_plugin-render_math (pelican3.7.0)
$ python test_math.py
...WARNING: macros where defined more than once, the last definition is used
Macro circ defined in
/home/user/example1.tex, line 1
/home/user/example2.tex, line 1

.WARNING: macros where defined more than once, the last definition is used
Macro circ defined in
/home/user/example.tex, line 1
/home/user/example.tex, line 2

.
----------------------------------------------------------------------
Ran 5 tests in 0.000s

OK
```

To get the unit tests to run in Python 2.7, I did have to make one change, which is not included here, to the import statement in render_math.py, removing the "." relative import.

this is, I temporarily changed
```python
try:
    from . pelican_mathjax_markdown_extension import PelicanMathJaxExtension
except ImportError as e:
    PelicanMathJaxExtension = None
```

to
```python
try:
    from pelican_mathjax_markdown_extension import PelicanMathJaxExtension
except ImportError as e:
    PelicanMathJaxExtension = None
```