### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,7 +132,7 @@ Markdown
 This plugin implements a custom extension for markdown resulting in math
 being a "first class citizen" for Pelican. 
 
-###Inlined Math
+### Inlined Math
 Math between `$`..`$`, for example, `$`x^2`$`, will be rendered inline
 with respect to the current html block. Note: To use inline math, there
 must *not* be any whitespace before the ending `$`. So for example:
@@ -140,11 +140,11 @@ must *not* be any whitespace before the ending `$`. So for example:
  * **Relevant inline math**: `$e=mc^2$`
  * **Will not render as inline math**: `$40 vs $50`
 
-###Displayed Math
+### Displayed Math
 Math between `$$`..`$$`, for example, `$$`x^2`$$`, will be rendered centered in a
 new paragraph.
 
-###Latex Macros
+### Latex Macros
 Latex macros are supported, and are automatically treated like displayed math 
 (i.e. it is wrapped in `div` tag). For example, `begin{equation}` x^2 `\end{equation}`,
 will be rendered in its own block with a right justified equation number
@@ -158,14 +158,14 @@ reStructuredText
 If there is math detected in reStructuredText document, the plugin will automatically
 set the [math_output](http://docutils.sourceforge.net/docs/user/config.html#math-output) configuration setting to `MathJax`.
 
-###Inlined Math
+### Inlined Math
 Inlined math needs to use the [math role](http://docutils.sourceforge.net/docs/ref/rst/roles.html#math):
 
 ```
 The area of a circle is :math:`A_\text{c} = (\pi/4) d^2`.
 ```
 
-###Displayed Math
+### Displayed Math
 Displayed math uses the [math block](http://docutils.sourceforge.net/docs/ref/rst/directives.html#math):
 
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
